### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -34,8 +34,7 @@ func AllBooks() ([]Book, error) {
 // The user input is not parameterized. Instead of using fmt.Sprintf() to build
 // the query, you should be using a parameterized query.
 func NameQuery(r string) ([]Book, error) {
-	// Fix: rows, err := DB.Query("SELECT * FROM books WHERE name = ?", r)
-	rows, err := DB.Query(fmt.Sprintf("SELECT * FROM books WHERE name = '%s'", r))
+	rows, err := DB.Query("SELECT * FROM books WHERE name = ?", r)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +52,7 @@ func NameQuery(r string) ([]Book, error) {
 // The user input is not parameterized. Instead of using fmt.Sprintf() to build
 // the query, you should be using a parameterized query.
 func AuthorQuery(r string) ([]Book, error) {
-	// Fix: rows, err := DB.Query("SELECT * FROM books WHERE author = ?", r)
-	rows, err := DB.Query(fmt.Sprintf("SELECT * FROM books WHERE author = '%s'", r))
+	rows, err := DB.Query("SELECT * FROM books WHERE author = ?", r)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +70,7 @@ func AuthorQuery(r string) ([]Book, error) {
 // The user input is not parameterized. Instead of using fmt.Sprintf() to build
 // the query, you should be using a parameterized query.
 func ReadQuery(r string) ([]Book, error) {
-	// Fix: rows, err := DB.Query("SELECT * FROM books WHERE read = ?", r)
-	rows, err := DB.Query(fmt.Sprintf("SELECT * FROM books WHERE read = '%s'", r))
+	rows, err := DB.Query("SELECT * FROM books WHERE read = ?", r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/burrito-party/advanced-security-go/security/code-scanning/1](https://github.com/burrito-party/advanced-security-go/security/code-scanning/1)

To fix the issue, the SQL queries in the `NameQuery`, `AuthorQuery`, and `ReadQuery` functions should use parameterized queries instead of string concatenation with `fmt.Sprintf`. Parameterized queries safely embed user input into the query by treating it as a parameter rather than executable SQL code, thereby preventing SQL injection.

**Steps to fix:**
1. Replace the `fmt.Sprintf` calls in the `DB.Query` statements with parameterized queries using placeholders (`?`).
2. Pass the user-provided input (`r`) as an argument to the `DB.Query` method, corresponding to the placeholder in the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
